### PR TITLE
PackageInstallerSession: use ftruncate if fallocate is ENOTSUP

### DIFF
--- a/services/core/java/com/android/server/pm/PackageInstallerSession.java
+++ b/services/core/java/com/android/server/pm/PackageInstallerSession.java
@@ -440,7 +440,15 @@ public class PackageInstallerSession extends IPackageInstallerSession.Stub {
                 if (stageDir != null && deltaBytes > 0) {
                     mPm.freeStorage(params.volumeUuid, deltaBytes);
                 }
-                Libcore.os.posix_fallocate(targetFd, 0, lengthBytes);
+                try {
+                    Libcore.os.posix_fallocate(targetFd, 0, lengthBytes);
+                } catch (ErrnoException e) {
+                    if (e.errno == OsConstants.ENOTSUP) {
+                        Libcore.os.ftruncate(targetFd, lengthBytes);
+                    } else {
+                        throw e.rethrowAsIOException();
+                    }
+                }
             }
 
             if (offsetBytes > 0) {


### PR DESCRIPTION
When posix_fallocate is not supported (e.g. on ext3), fall
back to using ftruncate instead.

Change-Id: I8f7792ed3f43504df21e86cff79ed34f3ba795d7