### PR TITLE
windowmanager: Add support for blur effects

### DIFF
--- a/core/java/android/view/SurfaceControl.java
+++ b/core/java/android/view/SurfaceControl.java
@@ -185,6 +185,11 @@ public class SurfaceControl {
     public static final int FX_SURFACE_NORMAL   = 0x00000000;
 
     /**
+     * Surface creation flag: Creates a blur surface.
+     */
+    public static final int FX_SURFACE_BLUR = 0x00010000;
+
+    /**
      * Surface creation flag: Creates a Dim surface.
      * Everything behind this surface is dimmed by the amount specified
      * in {@link #setAlpha}.  It is an error to lock a Dim surface, since it

--- a/core/java/android/view/WindowManagerPolicy.java
+++ b/core/java/android/view/WindowManagerPolicy.java
@@ -728,6 +728,11 @@ public interface WindowManagerPolicy {
     public WindowState getWinShowWhenLockedLw();
 
     /**
+     * Returns the current keyguard panel, if such a thing exists.
+     */
+    public WindowState getWinKeyguardPanelLw();
+
+    /**
      * Called when the system would like to show a UI to indicate that an
      * application is starting.  You can use this to add a
      * APPLICATION_STARTING_TYPE window with the given appToken to the window

--- a/core/res/res/values/cm_symbols.xml
+++ b/core/res/res/values/cm_symbols.xml
@@ -79,4 +79,7 @@
 
     <!-- PlatLogo -->
     <java-symbol type="drawable" name="platlogo_lineage" />
+
+    <!-- Blur effects -->
+    <java-symbol type="bool" name="config_uiBlurEnabled" />
 </resources>

--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -2793,4 +2793,8 @@
 
     <!-- Boolean to enable stk functionality on Samsung phones -->
     <bool name="config_samsung_stk">false</bool>
+
+    <!-- Support in Surfaceflinger for blur layers.
+         NOTE: This requires additional hardware-specific code. -->
+    <bool name="config_uiBlurEnabled">false</bool>
 </resources>

--- a/packages/SystemUI/AndroidManifest_cm.xml
+++ b/packages/SystemUI/AndroidManifest_cm.xml
@@ -30,6 +30,9 @@
     <uses-permission android:name="cyanogenmod.permission.READ_WEATHER" />
     <protected-broadcast android:name="com.cyanogenmod.lockclock.action.FORCE_WEATHER_UPDATE" />
 
+    <!-- Blur surface -->
+    <uses-permission android:name="android.permission.ACCESS_SURFACE_FLINGER" />
+
     <application>
 
         <activity-alias

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/BlurLayer.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/BlurLayer.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2014 The Linux Foundation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of The Linux Foundation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.android.systemui.statusbar.phone;
+
+import android.graphics.PixelFormat;
+import android.util.Slog;
+import android.view.SurfaceControl;
+import android.view.SurfaceSession;
+
+class BlurLayer {
+    private static final boolean DEBUG = true;
+    private static final String TAG = BlurLayer.class.getSimpleName();
+
+    /** Actual surface that blurs */
+    private SurfaceControl mBlurSurface;
+
+    /** Last values passed to mBlurSurface.setSize() */
+    private int mW, mH;
+
+    /** True after mBlurSurface.show() has been called, false after mBlurSurface.hide(). */
+    private boolean mShowing = false;
+
+    BlurLayer(int w, int h, int layer, String name) {
+        mW = w;
+        mH = h;
+
+        SurfaceControl.openTransaction();
+        try {
+            mBlurSurface = new SurfaceControl(new SurfaceSession(), TAG + "_" + name, 16, 16,
+                    PixelFormat.OPAQUE, SurfaceControl.FX_SURFACE_BLUR | SurfaceControl.HIDDEN);
+            mBlurSurface.setLayerStack(0);
+            mBlurSurface.setPosition(0, 0);
+            mBlurSurface.setSize(mW, mH);
+            mBlurSurface.setLayer(layer);
+        } catch (Exception e) {
+            Slog.e(TAG, "Exception creating BlurLayer surface", e);
+        } finally {
+            SurfaceControl.closeTransaction();
+        }
+    }
+
+    void setSize(int w, int h) {
+        if (mBlurSurface == null || (mW == w && mH == h)) {
+            return;
+        }
+
+        SurfaceControl.openTransaction();
+        try {
+            mBlurSurface.setSize(w, h);
+            mW = w;
+            mH = h;
+        } catch (RuntimeException e) {
+            Slog.w(TAG, "Failure setting setSize immediately", e);
+        } finally {
+            SurfaceControl.closeTransaction();
+        }
+    }
+
+    void show() {
+        if (mBlurSurface == null || mShowing) {
+            return;
+        }
+
+        SurfaceControl.openTransaction();
+        try {
+            mBlurSurface.show();
+            mShowing = true;
+        } catch (RuntimeException e) {
+             Slog.w(TAG, "Failure show()", e);
+        } finally {
+            SurfaceControl.closeTransaction();
+        }
+    }
+
+    void hide() {
+        if (mBlurSurface == null || !mShowing) {
+            return;
+        }
+
+        SurfaceControl.openTransaction();
+        try {
+            mBlurSurface.hide();
+            mShowing = false;
+        } catch (RuntimeException e) {
+             Slog.w(TAG, "Failure hide()", e);
+        } finally {
+            SurfaceControl.closeTransaction();
+        }
+    }
+}
+

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
@@ -2510,6 +2510,10 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
                 }
             }
         }
+
+        if (mStatusBarWindowManager != null) {
+            mStatusBarWindowManager.setShowingMedia(hasArtwork);
+        }
         Trace.endSection();
     }
 
@@ -3713,7 +3717,9 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
         mStatusBarWindowManager = new StatusBarWindowManager(mContext);
         mRemoteInputController = new RemoteInputController(mStatusBarWindowManager,
                 mHeadsUpManager);
+        mStatusBarWindowManager.setShowingMedia(mKeyguardShowingMedia);
         mStatusBarWindowManager.add(mStatusBarWindow, getStatusBarHeight());
+        mKeyguardMonitor.addCallback(mStatusBarWindowManager);
     }
 
     // called by makeStatusbar and also by PhoneStatusBarView
@@ -3938,6 +3944,7 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
         updateRowStates();
         mScreenPinningRequest.onConfigurationChanged();
         mNetworkController.onConfigurationChanged();
+        mStatusBarWindowManager.onConfigurationChanged();
     }
 
     @Override

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarKeyguardViewManager.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarKeyguardViewManager.java
@@ -236,6 +236,7 @@ public class StatusBarKeyguardViewManager implements RemoteInputController.Callb
             updateStates();
         }
         mPhoneStatusBar.onScreenTurnedOn();
+        mStatusBarWindowManager.onKeyguardChanged();
         Trace.endSection();
     }
 

--- a/services/core/java/com/android/server/policy/PhoneWindowManager.java
+++ b/services/core/java/com/android/server/policy/PhoneWindowManager.java
@@ -2973,6 +2973,11 @@ public class PhoneWindowManager implements WindowManagerPolicy {
         return mWinShowWhenLocked;
     }
 
+    @Override
+    public WindowState getWinKeyguardPanelLw() {
+        return mKeyguardPanel;
+    }
+
     /** {@inheritDoc} */
     @Override
     public View addStartingWindow(IBinder appToken, String packageName, int theme,

--- a/services/core/java/com/android/server/wm/WindowAnimator.java
+++ b/services/core/java/com/android/server/wm/WindowAnimator.java
@@ -46,6 +46,8 @@ import static com.android.server.wm.WindowSurfacePlacer.SET_WALLPAPER_ACTION_PEN
 import static com.android.server.wm.WindowSurfacePlacer.SET_WALLPAPER_MAY_CHANGE;
 
 import android.content.Context;
+import android.database.ContentObserver;
+import android.os.Handler;
 import android.os.Trace;
 import android.util.Slog;
 import android.util.SparseArray;
@@ -57,6 +59,8 @@ import android.view.WindowManager;
 import android.view.WindowManagerPolicy;
 import android.view.animation.AlphaAnimation;
 import android.view.animation.Animation;
+
+import cyanogenmod.providers.CMSettings;
 
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -134,11 +138,20 @@ public class WindowAnimator {
         }
     }
 
+    private boolean mKeyguardBlurEnabled;
+
     WindowAnimator(final WindowManagerService service) {
         mService = service;
         mContext = service.mContext;
         mPolicy = service.mPolicy;
         mWindowPlacerLocked = service.mWindowPlacerLocked;
+
+        final boolean isBlurSupported = mContext.getResources().getBoolean(
+                com.android.internal.R.bool.config_uiBlurEnabled);
+        if (isBlurSupported) {
+            final SettingsObserver observer = new SettingsObserver(new Handler());
+            observer.observe(mContext);
+        }
 
         mAnimationFrameCallback = new Choreographer.FrameCallback() {
             public void doFrame(long frameTimeNs) {
@@ -277,6 +290,14 @@ public class WindowAnimator {
         // Only hide windows if the keyguard is active and not animating away.
         boolean keyguardOn = mPolicy.isKeyguardShowingOrOccluded()
                 && mForceHiding != KEYGUARD_ANIMATING_OUT;
+
+        final WindowState winKeyguardPanel = (WindowState) mPolicy.getWinKeyguardPanelLw();
+        // If a keyguard panel is currently being shown, we should
+        // continue to hide the windows as if blur is disabled.
+        if (winKeyguardPanel == null) {
+            keyguardOn &= !mKeyguardBlurEnabled;
+        }
+
         boolean hideDockDivider = win.mAttrs.type == TYPE_DOCK_DIVIDER
                 && win.getDisplayContent().getDockedStackLocked() == null;
         return keyguardOn && !allowWhenLocked && (win.getDisplayId() == Display.DEFAULT_DISPLAY)
@@ -295,7 +316,7 @@ public class WindowAnimator {
         final boolean keyguardGoingAwayWithWallpaper =
                 (mKeyguardGoingAwayFlags & KEYGUARD_GOING_AWAY_FLAG_WITH_WALLPAPER) != 0;
 
-        if (mKeyguardGoingAway) {
+        if (mKeyguardGoingAway && !mKeyguardBlurEnabled) {
             for (int i = windows.size() - 1; i >= 0; i--) {
                 WindowState win = windows.get(i);
                 if (!mPolicy.isKeyguardHostWindow(win.mAttrs)) {
@@ -309,7 +330,8 @@ public class WindowAnimator {
 
                         // Create a new animation to delay until keyguard is gone on its own.
                         winAnimator.mAnimation = new AlphaAnimation(1.0f, 1.0f);
-                        winAnimator.mAnimation.setDuration(KEYGUARD_ANIM_TIMEOUT_MS);
+                        winAnimator.mAnimation.setDuration(mKeyguardBlurEnabled
+                                ? 0 : KEYGUARD_ANIM_TIMEOUT_MS);
                         winAnimator.mAnimationIsEntrance = false;
                         winAnimator.mAnimationStartTime = -1;
                         winAnimator.mKeyguardGoingAwayAnimation = true;
@@ -386,7 +408,8 @@ public class WindowAnimator {
                         if (nowAnimating && win.mWinAnimator.mKeyguardGoingAwayAnimation) {
                             mForceHiding = KEYGUARD_ANIMATING_OUT;
                         } else {
-                            mForceHiding = win.isDrawnLw() ? KEYGUARD_SHOWN : KEYGUARD_NOT_SHOWN;
+                            mForceHiding = win.isDrawnLw() && !mKeyguardBlurEnabled
+                                    ? KEYGUARD_SHOWN : KEYGUARD_NOT_SHOWN;
                         }
                     }
                     if (DEBUG_KEYGUARD || DEBUG_VISIBILITY) Slog.v(TAG,
@@ -1005,5 +1028,24 @@ public class WindowAnimator {
 
     void orAnimating(boolean animating) {
         mAnimating |= animating;
+    }
+
+    private class SettingsObserver extends ContentObserver {
+        SettingsObserver(Handler handler) {
+            super(handler);
+        }
+
+        void observe(Context context) {
+            context.getContentResolver().registerContentObserver(
+                    CMSettings.Secure.getUriFor(CMSettings.Secure.LOCK_SCREEN_BLUR_ENABLED),
+                    false, this);
+            onChange(true);
+        }
+
+        @Override
+        public void onChange(boolean selfChange) {
+            mKeyguardBlurEnabled = CMSettings.Secure.getInt(mContext.getContentResolver(),
+                    CMSettings.Secure.LOCK_SCREEN_BLUR_ENABLED, 1) == 1;
+        }
     }
 }


### PR DESCRIPTION
  * Support for blur layer on the lockscreen
  * Additional code for blur-behind and surface-blur has
    been removed from this commit as it is not in use.

  * Original work by CodeAurora / Qualcomm
  * Contributions from:
    - Steve Kondik
    - Danesh Mondegarian
    - Roman Birg
    - Clark Scheff
    - Michael Bestas

Change-Id: I6285905a4e3c00dfb5471876d0cfb16b4b4e9893