### PR TITLE
PowerManagerService: add a config to light up buttons only when pressed

### DIFF
--- a/core/res/res/values/cm_symbols.xml
+++ b/core/res/res/values/cm_symbols.xml
@@ -108,4 +108,7 @@
 
     <!-- Whether notify fingerprint client of successful cancelled authentication -->
     <java-symbol type="bool" name="config_notifyClientOnFingerprintCancelSuccess" />
+
+    <!-- Whether light up buttons only when pressed -->
+    <java-symbol type="bool" name="config_buttonLightOnKeypressOnly" />
 </resources>

--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -2947,4 +2947,8 @@
 
     <!-- Whether notify fingerprint client of successful cancelled authentication -->
     <bool name="config_notifyClientOnFingerprintCancelSuccess">false</bool>
+
+    <!-- If enabled, capacitive keys will only light up when pressed.
+         Otherwise, the buttons will light up whenever the user interacts with the device -->
+    <bool name="config_buttonLightOnKeypressOnly">false</bool>
 </resources>


### PR DESCRIPTION
 * Right now capactive, lit hardware keys are being
   lit every time you either touch them or the screen.

   But some devices handle this differently on stock:

   Display touch => buttons not lit
   Buttons touch => buttons lit

 * Thus, add a config in order to make this behavior
   consistent to stock ROMs for some devices.

Change-Id: I3bc214d9062f6762ebe5ab0fff949da0460a0fec