### PR TITLE
AppOps: Prevent deadlock when making note of applications

### DIFF
--- a/services/core/java/com/android/server/AppOpsService.java
+++ b/services/core/java/com/android/server/AppOpsService.java
@@ -80,6 +80,7 @@ import com.android.internal.util.ArrayUtils;
 import com.android.internal.util.FastXmlSerializer;
 import com.android.internal.util.Preconditions;
 import com.android.internal.util.XmlUtils;
+import com.android.server.am.ActivityManagerService;
 import com.android.server.PermissionDialogReqQueue.PermissionDialogReq;
 
 import libcore.util.EmptyArray;
@@ -104,6 +105,7 @@ public class AppOpsService extends IAppOpsService.Stub {
     final boolean mStrictEnable;
     AppOpsPolicy mPolicy;
     private PowerManager mPowerManager;
+    private final ActivityManagerService mActivityManagerService;
 
     private static final int[] PRIVACY_GUARD_OP_STATES = new int[] {
         AppOpsManager.OP_COARSE_LOCATION,
@@ -286,11 +288,12 @@ public class AppOpsService extends IAppOpsService.Stub {
         }
     }
 
-    public AppOpsService(File storagePath, Handler handler) {
+    public AppOpsService(File storagePath, Handler handler, ActivityManagerService service) {
         mFile = new AtomicFile(storagePath);
         mHandler = handler;
         mLooper = Looper.myLooper();
         mStrictEnable = AppOpsManager.isStrictEnable();
+        mActivityManagerService = service;
         readState();
     }
 
@@ -1159,7 +1162,7 @@ public class AppOpsService extends IAppOpsService.Stub {
                     op.ignoredCount++;
                     return switchOp.mode;
                 } else if (switchOp.mode == AppOpsManager.MODE_ASK) {
-                    if (Looper.myLooper() == mLooper) {
+                    if (Looper.myLooper() == mLooper || Thread.holdsLock(mActivityManagerService)) {
                         Log.e(TAG,
                                 "noteOperation: This method will deadlock if called from the main thread. (Code: "
                                         + code
@@ -1295,7 +1298,7 @@ public class AppOpsService extends IAppOpsService.Stub {
                 broadcastOpIfNeeded(code);
                 return AppOpsManager.MODE_ALLOWED;
             } else {
-                if (Looper.myLooper() == mLooper) {
+                if (Looper.myLooper() == mLooper || Thread.holdsLock(mActivityManagerService)) {
                     Log.e(TAG,
                             "startOperation: This method will deadlock if called from the main thread. (Code: "
                                     + code

--- a/services/core/java/com/android/server/am/ActivityManagerService.java
+++ b/services/core/java/com/android/server/am/ActivityManagerService.java
@@ -2843,7 +2843,7 @@ public final class ActivityManagerService extends ActivityManagerNative
 
         mProcessStats = new ProcessStatsService(this, new File(systemDir, "procstats"));
 
-        mAppOpsService = new AppOpsService(new File(systemDir, "appops.xml"), mHandler);
+        mAppOpsService = new AppOpsService(new File(systemDir, "appops.xml"), mHandler, this);
         mAppOpsService.startWatchingMode(AppOpsManager.OP_RUN_IN_BACKGROUND, null,
                 new IAppOpsCallback.Stub() {
                     @Override public void opChanged(int op, int uid, String packageName) {


### PR DESCRIPTION
If noteOperation() is called with ActivityManagerService locked,
AppOpsService won't be able to show the PermissionDialog, causing
noteOperation() to wait indefinitely. Keep a reference to the
current ActivityManagerService instance so that we can check
whether showing the PermissionDialog is safe or not.

Even though there's currently no code path that causes startOperation()
to be called with ActivityManagerService locked, add the same check
there to prevent the same from happening in future.

BUGBASH-17

Change-Id: I118aac6ddf91774a038d73047162cfdb8395e58d