### PR TITLE
base: audioservice: Set BT_SCO status

### DIFF
--- a/services/core/java/com/android/server/audio/AudioService.java
+++ b/services/core/java/com/android/server/audio/AudioService.java
@@ -2913,8 +2913,10 @@ public class AudioService extends IAudioService.Stub {
     public void setBluetoothScoOnInt(boolean on) {
         if (on) {
             mForcedUseForComm = AudioSystem.FORCE_BT_SCO;
+            AudioSystem.setParameters("BT_SCO=on");
         } else if (mForcedUseForComm == AudioSystem.FORCE_BT_SCO) {
             mForcedUseForComm = AudioSystem.FORCE_NONE;
+            AudioSystem.setParameters("BT_SCO=off");
         }
 
         sendMsg(mAudioHandler, MSG_SET_FORCE_USE, SENDMSG_QUEUE,


### PR DESCRIPTION
It is expected from audio HAL during BT SCO routing.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Ifdf7529ff292e9f73fc820400ccc7b6ac7ad112a