### PR TITLE
PowerManager: Allow to distinguish different keypresses

### DIFF
--- a/core/java/android/os/PowerManager.java
+++ b/core/java/android/os/PowerManager.java
@@ -334,6 +334,14 @@ public final class PowerManager {
     public static final int USER_ACTIVITY_FLAG_INDIRECT = 1 << 1;
 
     /**
+     * User activity flag: Certain hardware buttons are not supposed to
+     * activate hardware button illumination.  This flag indicates a
+     * button event from one of those buttons.
+     * @hide
+     */
+    public static final int USER_ACTIVITY_FLAG_NO_BUTTON_LIGHTS = 1 << 2;
+
+    /**
      * Go to sleep reason code: Going to sleep due by application request.
      * @hide
      */

--- a/services/core/java/com/android/server/power/PowerManagerService.java
+++ b/services/core/java/com/android/server/power/PowerManagerService.java
@@ -1316,8 +1316,11 @@ public final class PowerManagerService extends SystemService
             } else {
                 if (eventTime > mLastUserActivityTime) {
                     mButtonPressed = event == PowerManager.USER_ACTIVITY_EVENT_BUTTON;
-                    if ((mButtonLightOnKeypressOnly && mButtonPressed)
-                            || eventTime == mLastWakeTime) {
+                    if (eventTime == mLastWakeTime ||
+                            (mButtonLightOnKeypressOnly &&
+                                    mButtonPressed &&
+                                    (flags & PowerManager.USER_ACTIVITY_FLAG_NO_BUTTON_LIGHTS)
+                                            == 0)) {
                         mButtonPressed = true;
                         mLastButtonActivityTime = eventTime;
                     }

--- a/services/core/jni/com_android_server_input_InputManagerService.cpp
+++ b/services/core/jni/com_android_server_input_InputManagerService.cpp
@@ -240,7 +240,7 @@ public:
             const KeyEvent* keyEvent, uint32_t policyFlags);
     virtual bool dispatchUnhandledKey(const sp<InputWindowHandle>& inputWindowHandle,
             const KeyEvent* keyEvent, uint32_t policyFlags, KeyEvent* outFallbackKeyEvent);
-    virtual void pokeUserActivity(nsecs_t eventTime, int32_t eventType);
+    virtual void pokeUserActivity(nsecs_t eventTime, int32_t eventType, int32_t keyCode);
     virtual bool checkInjectEventsPermissionNonReentrant(
             int32_t injectorPid, int32_t injectorUid);
 
@@ -1078,8 +1078,8 @@ bool NativeInputManager::dispatchUnhandledKey(const sp<InputWindowHandle>& input
     return result;
 }
 
-void NativeInputManager::pokeUserActivity(nsecs_t eventTime, int32_t eventType) {
-    android_server_PowerManagerService_userActivity(eventTime, eventType);
+void NativeInputManager::pokeUserActivity(nsecs_t eventTime, int32_t eventType, int32_t keyCode) {
+    android_server_PowerManagerService_userActivity(eventTime, eventType, keyCode);
 }
 
 

--- a/services/core/jni/com_android_server_power_PowerManagerService.h
+++ b/services/core/jni/com_android_server_power_PowerManagerService.h
@@ -24,7 +24,7 @@
 
 namespace android {
 
-extern void android_server_PowerManagerService_userActivity(nsecs_t eventTime, int32_t eventType);
+extern void android_server_PowerManagerService_userActivity(nsecs_t eventTime, int32_t eventType, int32_t keyCode);
 
 } // namespace android
 


### PR DESCRIPTION
* Use keypress info to exclude pressing volume keys from
  illuminating HW buttons in config_buttonLightOnKeypressOnly
  mode.

Change-Id: I6bfc7ddd075e12e1ad10c3663a63e80c8d7f983d
Signed-off-by: Corinna Vinschen <xda@vinschen.de>