### PR TITLE
Prevent deadlock when using always-on legacy VPNs

### DIFF
--- a/core/java/android/hardware/input/InputManager.java
+++ b/core/java/android/hardware/input/InputManager.java
@@ -1005,6 +1005,16 @@ public final class InputManager {
     }
 
     /**
+     * Set cursor visibility. By default the cursor is visible but it can be hidden
+     * by calling this method. The cursor settings are not saved when an activity is
+     * paused. For this reason, an app must call this method everytime it is resumed.
+     * @hide
+     */
+    public void setCursorVisibility(boolean visible) {
+        /* stub */
+    }
+
+    /**
      * Listens for changes in input devices.
      */
     public interface InputDeviceListener {

--- a/services/core/java/com/android/server/ConnectivityService.java
+++ b/services/core/java/com/android/server/ConnectivityService.java
@@ -3241,14 +3241,16 @@ public class ConnectivityService extends IConnectivityManager.Stub
             log("reportNetworkConnectivity(" + nai.network.netId + ", " + hasConnectivity +
                     ") by " + uid);
         }
-        synchronized (nai) {
-            // Validating a network that has not yet connected could result in a call to
-            // rematchNetworkAndRequests() which is not meant to work on such networks.
-            if (!nai.everConnected) return;
+        synchronized (mVpns) {
+            synchronized (nai) {
+                // Validating a network that has not yet connected could result in a call to
+                // rematchNetworkAndRequests() which is not meant to work on such networks.
+                if (!nai.everConnected) return;
 
-            if (isNetworkWithLinkPropertiesBlocked(nai.linkProperties, uid, false)) return;
+                if (isNetworkWithLinkPropertiesBlocked(nai.linkProperties, uid, false)) return;
 
-            nai.networkMonitor.sendMessage(NetworkMonitor.CMD_FORCE_REEVALUATION, uid);
+                nai.networkMonitor.sendMessage(NetworkMonitor.CMD_FORCE_REEVALUATION, uid);
+            }
         }
     }
 


### PR DESCRIPTION
The following deadlock can happen when using an always-on legacy
VPN connection:

"Binder:7444_7" prio=5 tid=94 Blocked
  at com.android.server.connectivity.Vpn.isBlockingUid(Vpn.java:-1)
  - waiting to lock <0x032141f0> (a com.android.server.connectivity.Vpn) held by thread 52
  at com.android.server.ConnectivityService.isNetworkWithLinkPropertiesBlocked(ConnectivityService.java:1041)
  - locked <0x0791429e> (a android.util.SparseArray)

"ConnectivityServiceThread" prio=5 tid=52 Blocked
  at com.android.server.ConnectivityService.getLinkProperties(ConnectivityService.java:1351)
  - waiting to lock <0x09ec3887> (a com.android.server.connectivity.NetworkAgentInfo) held by thread 103
  at android.net.ConnectivityManager.getLinkProperties(ConnectivityManager.java:1065)
  at com.android.server.connectivity.Vpn$LegacyVpnRunner.<init>(Vpn.java:1524)
  at com.android.server.connectivity.Vpn.startLegacyVpn(Vpn.java:1413)
  - locked <0x032141f0> (a com.android.server.connectivity.Vpn)

"Binder:7444_D" prio=5 tid=103 Blocked
  at com.android.server.ConnectivityService.isNetworkWithLinkPropertiesBlocked(ConnectivityService.java:1039)
  - waiting to lock <0x0791429e> (a android.util.SparseArray) held by thread 94
  at com.android.server.ConnectivityService.reportNetworkConnectivity(ConnectivityService.java:3249)
  - locked <0x09ec3887> (a com.android.server.connectivity.NetworkAgentInfo)

Lock <0x0791429e> before <0x09ec3887> in thread 103 so that thread 94
will lock <0x032141f0> when <0x09ec3887> is not locked, allowing thread
52 to complete.

BUGBASH-1197

Change-Id: Ifaf4d4dc0053dd71ab0734e3f3b1e9839eece22a