### PR TITLE
fw/b: Return a KeyEvent instead of a boolean in KeyHandler

### DIFF
--- a/core/java/com/android/internal/os/DeviceKeyHandler.java
+++ b/core/java/com/android/internal/os/DeviceKeyHandler.java
@@ -20,7 +20,7 @@ public interface DeviceKeyHandler {
      * this special keys prior to pass the key to the active app.
      *
      * @param event The key event to be handled
-     * @return If the event is consume
+     * @return null if event is consumed, KeyEvent to be handled otherwise
      */
-    public boolean handleKeyEvent(KeyEvent event);
+    public KeyEvent handleKeyEvent(KeyEvent event);
 }

--- a/services/core/java/com/android/server/policy/PhoneWindowManager.java
+++ b/services/core/java/com/android/server/policy/PhoneWindowManager.java
@@ -4219,7 +4219,8 @@ public class PhoneWindowManager implements WindowManagerPolicy {
                 if (DEBUG_INPUT) {
                     Log.d(TAG, "Dispatching key event " + event + " to handler " + handler);
                 }
-                if (handler.handleKeyEvent(event)) {
+                event = handler.handleKeyEvent(event);
+                if (event == null) {
                     return true;
                 }
             } catch (Exception e) {


### PR DESCRIPTION
* Allows handlers to modify the event before sending it off
  to another KeyHandler class, to handle things like rotation

Change-Id: I481107e050f6323c5897260a5d241e64b4e031ac