### PR TITLE
Keyguard: Don't apply input restriction if disabled by profile

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/keyguard/KeyguardViewMediator.java
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/KeyguardViewMediator.java
@@ -993,6 +993,12 @@ public class KeyguardViewMediator extends SystemUI {
         }
     }
 
+    private boolean isProfileDisablingKeyguard() {
+        Profile profile = mProfileManager.getActiveProfile();
+        return profile != null &&
+                profile.getScreenLockMode().getValue() == Profile.LockMode.DISABLE;
+    }
+
     private boolean isKeyguardDisabled(int userId) {
         if (!mExternallyEnabled) {
             if (DEBUG) Log.d(TAG, "isKeyguardDisabled: keyguard is disabled externally");
@@ -1002,13 +1008,10 @@ public class KeyguardViewMediator extends SystemUI {
             if (DEBUG) Log.d(TAG, "isKeyguardDisabled: keyguard is disabled by setting");
             return true;
         }
-        Profile profile = mProfileManager.getActiveProfile();
-        if (profile != null) {
-            if (profile.getScreenLockMode().getValue() == Profile.LockMode.DISABLE) {
-                if (DEBUG) Log.d(TAG, "isKeyguardDisabled: keyguard is disabled by profile");
-                return true;
-            }
-         }
+        if (isProfileDisablingKeyguard()) {
+            if (DEBUG) Log.d(TAG, "isKeyguardDisabled: keyguard is disabled by profile");
+            return true;
+        }
         return false;
      }
 
@@ -1216,7 +1219,7 @@ public class KeyguardViewMediator extends SystemUI {
      * was suppressed by an app that disabled the keyguard or we haven't been provisioned yet.
      */
     public boolean isInputRestricted() {
-        return mShowing || mNeedToReshowWhenReenabled;
+        return (mShowing || mNeedToReshowWhenReenabled) && !isProfileDisablingKeyguard();
     }
 
     private void updateInputRestricted() {


### PR DESCRIPTION
setKeyguardEnabled() applies some input restrictions when disabling
the lockscreen. This causes issues when a system profile disables the
lockscreen via this method, e.g. the home button stops working until
a profile re-enables the lockscreen with setKeyguardEnabled(). If the
current profile is disabling keyguard, don't restrict the inputs.

BUGBASH-504

Change-Id: Iaaaabecaf19a18911d276a47f826dec3dec045c1